### PR TITLE
temp wc-compiler override for `shadowrootmode` attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3533,9 +3533,9 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.10.0.tgz",
+      "integrity": "sha512-GwtQw/cgbaCedoeguMc5YlRvHujDRTfpJxgglPAVT3LuJCRGXqG3nyckuV4mvblOBAPwePuP9T5nOTxbW/ZIRA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -3758,7 +3758,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.10.0"
       }
     },
     "@greenwood/plugin-adapter-vercel": {
@@ -6388,9 +6388,9 @@
       }
     },
     "wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.10.0.tgz",
+      "integrity": "sha512-GwtQw/cgbaCedoeguMc5YlRvHujDRTfpJxgglPAVT3LuJCRGXqG3nyckuV4mvblOBAPwePuP9T5nOTxbW/ZIRA==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "dependencies": {
     "htmx.org": "^1.9.4"
   },
+  "overrides": {
+    "wc-compiler": "~0.10.0"
+  },
   "devDependencies": {
     "@greenwood/cli": "~0.29.0",
     "@greenwood/plugin-adapter-vercel": "~0.29.0",


### PR DESCRIPTION
fast tracking this change until it can come through via a formal Greenwood release
https://github.com/ProjectEvergreen/greenwood/pull/1195