### PR TITLE
enhancement/upgrade to greenwood v0.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,16 @@
         "htmx.org": "^1.9.4"
       },
       "devDependencies": {
-        "@greenwood/cli": "~0.29.0",
-        "@greenwood/plugin-adapter-vercel": "~0.29.0",
-        "@greenwood/plugin-import-css": "~0.29.0",
+        "@greenwood/cli": "~0.29.2",
+        "@greenwood/plugin-adapter-vercel": "~0.29.2",
+        "@greenwood/plugin-import-css": "~0.29.2",
         "rimraf": "^5.0.1"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -46,7 +46,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.10.0"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -56,18 +56,18 @@
       }
     },
     "node_modules/@greenwood/plugin-adapter-vercel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.0.tgz",
-      "integrity": "sha512-SdG66AOddsZYjU/QuxodwLi/m7sSgoIWeUqyskLSEB7CCxgDDCJvVql4Vn1Z8JBfxJb+SBTc+MeLZUhiJiiclA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.2.tgz",
+      "integrity": "sha512-D3/pFfAGk9U7c8BZrw4tFrEMDNg3C28AQb+k4Jjiph0mTRBBn1omfgG3zaidKOSL/uoDsrRsTQA/BS0uph1HQA==",
       "dev": true,
       "peerDependencies": {
         "@greenwood/cli": "^0.28.0"
       }
     },
     "node_modules/@greenwood/plugin-import-css": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-import-css/-/plugin-import-css-0.29.0.tgz",
-      "integrity": "sha512-2FMk3qs8umOuR4bb4xSuW1bRGV1Pk1QS1QY6sk5BNhOIO5+ZphtuIrVTJUcfxHzLw4BBOG4Xws6LJCs5XfNfjw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-import-css/-/plugin-import-css-0.29.2.tgz",
+      "integrity": "sha512-5svwS4T+qyDTenX7XfKxKAtN4AijDk1HATWF0j1xcgN+9iNy4XAObBH1+kl0mYURL81m48Q8jCgptUmMp2yYyA==",
       "dev": true,
       "peerDependencies": {
         "@greenwood/cli": "^0.4.0"
@@ -3731,9 +3731,9 @@
   },
   "dependencies": {
     "@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -3762,15 +3762,15 @@
       }
     },
     "@greenwood/plugin-adapter-vercel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.0.tgz",
-      "integrity": "sha512-SdG66AOddsZYjU/QuxodwLi/m7sSgoIWeUqyskLSEB7CCxgDDCJvVql4Vn1Z8JBfxJb+SBTc+MeLZUhiJiiclA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.2.tgz",
+      "integrity": "sha512-D3/pFfAGk9U7c8BZrw4tFrEMDNg3C28AQb+k4Jjiph0mTRBBn1omfgG3zaidKOSL/uoDsrRsTQA/BS0uph1HQA==",
       "dev": true
     },
     "@greenwood/plugin-import-css": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-import-css/-/plugin-import-css-0.29.0.tgz",
-      "integrity": "sha512-2FMk3qs8umOuR4bb4xSuW1bRGV1Pk1QS1QY6sk5BNhOIO5+ZphtuIrVTJUcfxHzLw4BBOG4Xws6LJCs5XfNfjw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-import-css/-/plugin-import-css-0.29.2.tgz",
+      "integrity": "sha512-5svwS4T+qyDTenX7XfKxKAtN4AijDk1HATWF0j1xcgN+9iNy4XAObBH1+kl0mYURL81m48Q8jCgptUmMp2yYyA==",
       "dev": true
     },
     "@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -29,13 +29,10 @@
   "dependencies": {
     "htmx.org": "^1.9.4"
   },
-  "overrides": {
-    "wc-compiler": "~0.10.0"
-  },
   "devDependencies": {
-    "@greenwood/cli": "~0.29.0",
-    "@greenwood/plugin-adapter-vercel": "~0.29.0",
-    "@greenwood/plugin-import-css": "~0.29.0",
+    "@greenwood/cli": "~0.29.2",
+    "@greenwood/plugin-adapter-vercel": "~0.29.2",
+    "@greenwood/plugin-import-css": "~0.29.2",
     "rimraf": "^5.0.1"
   }
 }


### PR DESCRIPTION
This should pull in latest **wc-compiler** from Greenwood with [`shadowrootmode` support](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.29.2)
![Screenshot 2024-01-27 at 4 50 50 PM](https://github.com/thescientist13/greenwood-htmx/assets/895923/eb9f1873-6aa5-43c2-a19b-03927a6c46fe)
```sh
✗ npm ls wc-compiler
greenwood-htmx@1.0.0 /Users/owenbuckley/Workspace/github/greenwood-htmx
└─┬ @greenwood/cli@0.29.2
  └── wc-compiler@0.10.0
```