### PR TITLE
enhancement/upgrade htmx 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "htmx.org": "^2.0.0-alpha1"
+        "htmx.org": "^2.0.0-beta2"
       },
       "devDependencies": {
         "@greenwood/cli": "~0.29.2",
@@ -1612,9 +1612,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "2.0.0-alpha1",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-alpha1.tgz",
-      "integrity": "sha512-Rggz16CYzkdKN5cq1xjLdPVQ3RQLIrzq2kacf+xO0qDRTREuLouD7CMwdLpN4xtkmzEKDFCPweKaQ85dC3Ruyw=="
+      "version": "2.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-beta2.tgz",
+      "integrity": "sha512-1y8nT1T/Mt5iPMXSIWWJOj3nLiki9FhaQjESfPzw/tguWMCqp7VOL7M3o8f6N2g3F7mExisKiNnTHJLX7R0m1A=="
     },
     "node_modules/http-assert": {
       "version": "1.5.0",
@@ -4963,9 +4963,9 @@
       "dev": true
     },
     "htmx.org": {
-      "version": "2.0.0-alpha1",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-alpha1.tgz",
-      "integrity": "sha512-Rggz16CYzkdKN5cq1xjLdPVQ3RQLIrzq2kacf+xO0qDRTREuLouD7CMwdLpN4xtkmzEKDFCPweKaQ85dC3Ruyw=="
+      "version": "2.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-beta2.tgz",
+      "integrity": "sha512-1y8nT1T/Mt5iPMXSIWWJOj3nLiki9FhaQjESfPzw/tguWMCqp7VOL7M3o8f6N2g3F7mExisKiNnTHJLX7R0m1A=="
     },
     "http-assert": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "htmx.org": "^1.9.4"
+        "htmx.org": "^2.0.0-alpha1"
       },
       "devDependencies": {
         "@greenwood/cli": "~0.29.2",
@@ -1612,9 +1612,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.4.tgz",
-      "integrity": "sha512-GB9afD20gYw708z2PjClwlDgNtD1p4RYQtlDKak/JyMhrgiSL8sPfGqdkNmSLrhuCFekWw9mLpRNK/+Xn9aayA=="
+      "version": "2.0.0-alpha1",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-alpha1.tgz",
+      "integrity": "sha512-Rggz16CYzkdKN5cq1xjLdPVQ3RQLIrzq2kacf+xO0qDRTREuLouD7CMwdLpN4xtkmzEKDFCPweKaQ85dC3Ruyw=="
     },
     "node_modules/http-assert": {
       "version": "1.5.0",
@@ -4963,9 +4963,9 @@
       "dev": true
     },
     "htmx.org": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.4.tgz",
-      "integrity": "sha512-GB9afD20gYw708z2PjClwlDgNtD1p4RYQtlDKak/JyMhrgiSL8sPfGqdkNmSLrhuCFekWw9mLpRNK/+Xn9aayA=="
+      "version": "2.0.0-alpha1",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-alpha1.tgz",
+      "integrity": "sha512-Rggz16CYzkdKN5cq1xjLdPVQ3RQLIrzq2kacf+xO0qDRTREuLouD7CMwdLpN4xtkmzEKDFCPweKaQ85dC3Ruyw=="
     },
     "http-assert": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "htmx.org": "^2.0.0-beta2"
+        "htmx.org": "^2.0.0"
       },
       "devDependencies": {
         "@greenwood/cli": "~0.29.2",
@@ -1612,9 +1612,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "2.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-beta2.tgz",
-      "integrity": "sha512-1y8nT1T/Mt5iPMXSIWWJOj3nLiki9FhaQjESfPzw/tguWMCqp7VOL7M3o8f6N2g3F7mExisKiNnTHJLX7R0m1A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0.tgz",
+      "integrity": "sha512-N0r1VjrqeCpig0mTi2/sooDZBeQlp1RBohnWQ/ufqc7ICaI0yjs04fNGhawm6+/HWhJFlcXn8MqOjWI9QGG2lQ=="
     },
     "node_modules/http-assert": {
       "version": "1.5.0",
@@ -4963,9 +4963,9 @@
       "dev": true
     },
     "htmx.org": {
-      "version": "2.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0-beta2.tgz",
-      "integrity": "sha512-1y8nT1T/Mt5iPMXSIWWJOj3nLiki9FhaQjESfPzw/tguWMCqp7VOL7M3o8f6N2g3F7mExisKiNnTHJLX7R0m1A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.0.tgz",
+      "integrity": "sha512-N0r1VjrqeCpig0mTi2/sooDZBeQlp1RBohnWQ/ufqc7ICaI0yjs04fNGhawm6+/HWhJFlcXn8MqOjWI9QGG2lQ=="
     },
     "http-assert": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "npm run serve"
   },
   "dependencies": {
-    "htmx.org": "^2.0.0-beta2"
+    "htmx.org": "^2.0.0"
   },
   "devDependencies": {
     "@greenwood/cli": "~0.29.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "npm run serve"
   },
   "dependencies": {
-    "htmx.org": "^1.9.4"
+    "htmx.org": "^2.0.0-alpha1"
   },
   "devDependencies": {
     "@greenwood/cli": "~0.29.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "npm run serve"
   },
   "dependencies": {
-    "htmx.org": "^2.0.0-alpha1"
+    "htmx.org": "^2.0.0-beta2"
   },
   "devDependencies": {
     "@greenwood/cli": "~0.29.2",


### PR DESCRIPTION
1. Upgrade to **htmx** 2.0
    - [2.0.0-alpha1](https://v2-0v2-0.htmx.org/posts/2024-01-26-htmx-2-0-0-alpha1-is-released/)
    - [2.0.0-beta2]( https://www.npmjs.com/package/htmx.org/v/2.0.0-beta2)

----

https://v2-0v2-0.htmx.org/migration-guide-htmx-1/